### PR TITLE
Unify brick apps

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -72,6 +72,7 @@ import System.Environment
 import System.Exit (exitFailure)
 import System.IO
 import System.Process
+import Debug.Trace (traceM)
 
 -- This is needed because brick's editTextField widget uses Text rather than String
 -- That means we can't use a Connector as the Form state, because it uses string
@@ -449,7 +450,7 @@ handleCommands evChan cmdChan = do
             ++ ":"
             ++ show connector.wsConnectorPort
         BPWS.runClient connector \handle -> do
-          putStrLn "connected!"
+          hPutStrLn stderr "connected!"
           putMVar connected ()
           writeBChan evChan EvConnected
           handleMsgs handle evChan buttplugCmdsChan
@@ -471,6 +472,7 @@ handleMsgs handle evChan buttplugCmdsChan = do
   Buttplug.sendMessage handle $ MsgRequestServerInfo 1 "VibeMenu" clientMessageVersion
   [servInfo@(MsgServerInfo 1 _ _ _)] <- Buttplug.receiveMessages handle
   writeBChan evChan $ ReceivedMessage servInfo
+  traceM "here 1"
 
   mapConcurrently_
     id

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,367 +1,524 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedRecordUpdate #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE ViewPatterns #-}
+
 module Main where
 
-
-import qualified Data.Text as T
-import Lens.Micro ((^.), (&), (%~), (.~))
-import Lens.Micro.TH
+import Brick
+import Brick.AttrMap qualified as A
+import Brick.BChan
+  ( BChan,
+    newBChan,
+    readBChan,
+    writeBChan,
+  )
+import Brick.Focus
+  ( focusGetCurrent,
+    focusRingCursor,
+  )
+import Brick.Forms
+  ( Form,
+    allFieldsValid,
+    checkboxField,
+    editPasswordField,
+    editShowableField,
+    editTextField,
+    focusedFormInputAttr,
+    formFocus,
+    formState,
+    handleFormEvent,
+    invalidFields,
+    invalidFormInputAttr,
+    newForm,
+    radioField,
+    renderForm,
+    setFieldValid,
+    (@@=),
+  )
+import Brick.Widgets.Border qualified as B
+import Brick.Widgets.Center qualified as C
+import Brick.Widgets.Edit qualified as E
+import Brick.Widgets.List qualified as L
+import Buttplug.Core (Device (..), Message (..), Vibrate (..), clientMessageVersion)
+import Buttplug.Core.Handle qualified as Buttplug
+import Buttplug.Core.WebSockets qualified as BPWS
+import Control.Concurrent.Async
+import Control.Concurrent.MVar
 import Control.Monad (forever)
 import Control.Monad.IO.Class
-import Control.Concurrent.Async
+import Data.Char (isDigit, ord)
 import Data.Foldable (traverse_)
+import Data.Maybe (catMaybes)
+import Data.Text qualified as T
+import Data.Vector (Vector)
+import Data.Vector qualified as Vec
+import Flow
+import Graphics.Vty qualified as V
+import Lens.Micro ((%~), (&), (.~), (^.))
+import Lens.Micro.TH
+import Streamly hiding ((<=>))
+import Streamly.Internal.Network.Inet.TCP (connect)
+import Streamly.Prelude (nil, (|:))
+import Streamly.Prelude qualified as S
 import System.Environment
 import System.Exit (exitFailure)
+import System.IO
 import System.Process
-import Data.Char (isDigit)
 
-import           Data.Maybe (catMaybes)
-import qualified Data.Vector as Vec
-import           Data.Vector (Vector)
-import           Data.Char (ord)
-
-import qualified Graphics.Vty as V
-import Brick
-import Brick.Forms ( Form
-                   , newForm
-                   , formState
-                   , formFocus
-                   , setFieldValid
-                   , renderForm
-                   , handleFormEvent
-                   , invalidFields
-                   , allFieldsValid
-                   , focusedFormInputAttr
-                   , invalidFormInputAttr
-                   , checkboxField
-                   , radioField
-                   , editShowableField
-                   , editTextField
-                   , editPasswordField
-                   , (@@=)
-                   )
-import Brick.Focus ( focusGetCurrent
-                   , focusRingCursor
-                   )
-import Brick.BChan ( newBChan
-                   , writeBChan
-                   , readBChan
-                   , BChan
-                   )
-import qualified Brick.Widgets.Edit as E
-import qualified Brick.Widgets.List as L
-import qualified Brick.Widgets.Border as B
-import qualified Brick.Widgets.Center as C
-import qualified Brick.AttrMap as A
-
-import Streamly hiding ((<=>))
-import Streamly.Prelude ((|:), nil)
-import qualified Streamly.Prelude as S
-
-import Flow
-
-import Buttplug.Core (Device(..), Message(..), Vibrate(..), clientMessageVersion)
-import Buttplug.Core.Handle     qualified as Buttplug
-import Buttplug.Core.WebSockets qualified as BPWS
-
-data ConnectScreenName = HostField
-                       | PortField
-          deriving (Eq, Ord, Show)
-
-data HostPort = HostPort { _host :: T.Text, _port :: Int }
+-- This is needed because brick's editTextField widget uses Text rather than String
+-- That means we can't use a Connector as the Form state, because it uses string
+data HostPort = HostPort {_host :: T.Text, _port :: Int}
   deriving (Show, Eq)
-
----------------------------
 
 makeLenses ''HostPort
 
--- This form is covered in the Brick User Guide; see the "Input Forms"
--- section.
-mkForm :: HostPort -> Form HostPort e ConnectScreenName
-mkForm =
-    let label s w = padBottom (Pad 1) $
-                    vLimit 1 (hLimit 15 $ str s <+> fill ' ') <+> w
-    in newForm [ label "Host" @@=
-                   editTextField host HostField (Just 1)
-               , label "Port" @@=
-                   editShowableField port PortField
-               ]
-
-theMap :: AttrMap
-theMap = attrMap V.defAttr
-  [ (E.editAttr, V.white `on` V.black)
-  , (E.editFocusedAttr, V.black `on` V.yellow)
-  , (invalidFormInputAttr, V.white `on` V.red)
-  , (focusedFormInputAttr, V.black `on` V.yellow)
-  , ("header", V.black `on` V.white)
-  , (L.listAttr,            V.white `on` V.black)
-  , (L.listSelectedAttr,    V.white `on` V.blue)
-  ]
-
-drawConnectScreen :: Form HostPort e ConnectScreenName -> [Widget ConnectScreenName]
-drawConnectScreen f = [C.vCenter $ C.hCenter form]
-    where
-        form = B.border $ padTop (Pad 1) $ hLimit 40 $ renderForm f
-
-connectScreen :: App (Form HostPort e ConnectScreenName) e ConnectScreenName
-connectScreen =
-    App { appDraw = drawConnectScreen
-        , appHandleEvent = \s ev ->
-            case ev of
-                VtyEvent V.EvResize {}     -> continue s
-                VtyEvent (V.EvKey V.KEsc [])   -> halt s
-                VtyEvent (V.EvKey V.KEnter []) -> halt s
-                _ -> do
-                    s' <- handleFormEvent ev s
-
-                    -- Example of external validation:
-                    continue $ setFieldValid
-                      (formState s' ^. port >= 0) PortField s'
-
-        , appChooseCursor = focusRingCursor formFocus
-        , appStartEvent = return
-        , appAttrMap = const theMap
-        }
-
-data VibeMenuName = MessageLog
-                  | DeviceMenu
+data VibeMenuName
+  = MessageLog
+  | DeviceMenu
+  | HostField
+  | PortField
   deriving (Eq, Ord, Show)
 
 -- Commands from the UI thread to the background thread
-data Command = CmdStopAll
-             | CmdVibrate Word Double
+data Command
+  = CmdConnect BPWS.Connector
+  | CmdButtplug ButtplugCommand
+  deriving (Show)
 
+data ButtplugCommand
+  = CmdStopAll
+  | CmdVibrate Word Double
+  deriving (Show)
 
-data VibeMenuState =
-  VibeMenuState { _messageLog :: L.List VibeMenuName Message
-                , _devices :: L.List VibeMenuName Device
-                , _cmdChan :: BChan Command
-                }
+-- events from bg thread to UI thread
+data CustomEvent
+  = ReceivedMessage Message
+  | ReceivedDeviceList [Device]
+  | EvDeviceAdded Device
+  | EvDeviceRemoved Word
+  | EvConnected
+
+data AppState = AppState
+  { _cmdChan :: BChan Command,
+    _appScreen :: ScreenState
+  }
+
+type ConnectScreenState = Form HostPort CustomEvent VibeMenuName
+
+data ScreenState
+  = ConnectScreenState ConnectScreenState
+  | ConnectingScreenState
+  | MainScreenState VibeMenuState
+
+data VibeMenuState = VibeMenuState
+  { _messageLog :: L.List VibeMenuName Message,
+    _devices :: L.List VibeMenuName Device
+  }
 
 makeLenses ''VibeMenuState
 
+-- This form is covered in the Brick User Guide; see the "Input Forms"
+-- section.
+mkForm :: HostPort -> Form HostPort e VibeMenuName
+mkForm =
+  let label s w =
+        padBottom (Pad 1) $
+          vLimit 1 (hLimit 15 $ str s <+> fill ' ') <+> w
+   in newForm
+        [ label "Host"
+            @@= editTextField host HostField (Just 1),
+          label "Port"
+            @@= editShowableField port PortField
+        ]
 
--- events from bg thread to UI thread
-data CustomEvent = ReceivedMessage Message
-                 | ReceivedDeviceList [Device]
-                 | EvDeviceAdded Device
-                 | EvDeviceRemoved Word
+theMap :: AttrMap
+theMap =
+  attrMap
+    V.defAttr
+    [ (E.editAttr, V.white `on` V.black),
+      (E.editFocusedAttr, V.black `on` V.yellow),
+      (invalidFormInputAttr, V.white `on` V.red),
+      (focusedFormInputAttr, V.black `on` V.yellow),
+      ("header", V.black `on` V.white),
+      (L.listAttr, V.white `on` V.black),
+      (L.listSelectedAttr, V.white `on` V.blue)
+    ]
 
-drawVibeMenu s = [ ui ]
-  where header = withAttr "header" . txtWrap
-        title = padBottom (Pad 1) $ header "VibeMenu"
-        deviceMenu =
-          header "Connected Devices"
-          <=>
-          padBottom (Pad 1) ( L.renderList listDrawDevice True $ s ^. devices)
-        receivedMsgLog =
-          header "Message log"
-          <=>
-          padBottom (Pad 1) (L.renderList listDrawElement False $ s ^. messageLog)
+connectScreenHandleEvent ::
+  ConnectScreenState ->
+  BChan Command ->
+  BrickEvent VibeMenuName CustomEvent ->
+  EventM VibeMenuName (Next AppState)
+connectScreenHandleEvent s cmdChan ev =
+  case ev of
+    VtyEvent V.EvResize {} -> continue $ sameState
+    VtyEvent (V.EvKey V.KEsc []) -> halt $ sameState
+    VtyEvent (V.EvKey V.KEnter []) -> do
+      -- TODO
+      -- check validity
+      -- tell bg thread to connect
+      -- switch to connecting state
+      undefined
+    _ -> do
+      form' <- handleFormEvent ev s
 
-        ui = title
-             <=>
-             deviceMenu
-             <=>
-             receivedMsgLog
+      -- Example of external validation:
+      continue $
+        connectState $
+          setFieldValid
+            (formState form' ^. port >= 0)
+            PortField
+            form'
+  where
+    sameState = AppState cmdChan (ConnectScreenState s)
+    connectState s' = AppState cmdChan (ConnectScreenState s')
+
+-- TODO remove
+-- connectScreen :: App ConnectScreenState e VibeMenuName
+-- connectScreen =
+--   App
+--     { appDraw = drawConnectScreen,
+--       appHandleEvent = connectScreenHandleEvent,
+--       appChooseCursor = focusRingCursor formFocus,
+--       appStartEvent = return,
+--       appAttrMap = const theMap
+--     }
+
+draw :: AppState -> [Widget VibeMenuName]
+draw (AppState _cmdChan s) = case s of
+  ConnectScreenState form -> drawConnectScreen form
+  ConnectingScreenState -> [header "Connecting..."] -- TODO show what we're connecting to
+  MainScreenState mss -> drawVibeMenu mss
+
+drawConnectScreen :: Form HostPort e VibeMenuName -> [Widget VibeMenuName]
+drawConnectScreen f = [C.vCenter $ C.hCenter form]
+  where
+    form = B.border $ padTop (Pad 1) $ hLimit 40 $ renderForm f
+
+header = withAttr "header" . txtWrap
+
+title = padBottom (Pad 1) $ header "VibeMenu"
+
+drawVibeMenu :: VibeMenuState -> [Widget VibeMenuName]
+drawVibeMenu s = [ui]
+  where
+    deviceMenu =
+      header "Connected Devices"
+        <=> padBottom (Pad 1) (L.renderList listDrawDevice True $ s ^. devices)
+    receivedMsgLog =
+      header "Message log"
+        <=> padBottom (Pad 1) (L.renderList listDrawElement False $ s ^. messageLog)
+
+    ui =
+      title
+        <=> deviceMenu
+        <=> receivedMsgLog
 
 listDrawDevice :: Bool -> Device -> Widget VibeMenuName
 listDrawDevice sel Device {..}
-  | sel       = withAttr L.listSelectedAttr $ txt label
-  | otherwise =                               txt label
-  where label :: T.Text
-        label = T.pack (show deviceIndex) <> " " <> deviceName
+  | sel = withAttr L.listSelectedAttr $ txt label
+  | otherwise = txt label
+  where
+    label :: T.Text
+    label = T.pack (show deviceIndex) <> " " <> deviceName
 
 listDrawElement :: (Show e) => Bool -> e -> Widget VibeMenuName
 listDrawElement sel a =
-     let selStr s = if sel
-                    then withAttr L.listSelectedAttr $ str s 
-                    else str s
-     in (selStr $ show a)
+  let selStr s =
+        if sel
+          then withAttr L.listSelectedAttr $ str s
+          else str s
+   in (selStr $ show a)
 
-vibeMenu :: App VibeMenuState CustomEvent VibeMenuName
+vibeMenu :: App AppState CustomEvent VibeMenuName
 vibeMenu =
-    App { appDraw = drawVibeMenu
-        , appHandleEvent = vibeMenuHandleEvent
-        , appChooseCursor = neverShowCursor -- TODO
-        , appStartEvent = return
-        , appAttrMap = const theMap
-        }
+  App
+    { appDraw = draw,
+      appHandleEvent = handleEvent,
+      appChooseCursor = chooseCursor,
+      appStartEvent = return,
+      appAttrMap = const theMap
+    }
 
-sendCommand :: BChan Command -> Command -> EventM n ()
+chooseCursor :: AppState -> [CursorLocation VibeMenuName] -> Maybe (CursorLocation VibeMenuName)
+chooseCursor (AppState _cmdChan screenState) ls = case screenState of
+  ConnectScreenState css -> focusRingCursor formFocus css ls
+  ConnectingScreenState -> neverShowCursor () ls -- TODO
+  MainScreenState _mss -> neverShowCursor () ls -- TODO
+
+sendCommand :: BChan Command -> Command -> EventM VibeMenuName ()
 sendCommand chan = liftIO . writeBChan chan
 
-vibeMenuHandleEvent :: VibeMenuState
-                    -> BrickEvent VibeMenuName CustomEvent
-                    -> EventM VibeMenuName (Next VibeMenuState)
-vibeMenuHandleEvent s = \case
+connectingStateHandleEvent :: BChan Command -> BrickEvent VibeMenuName CustomEvent -> EventM VibeMenuName (Next AppState)
+connectingStateHandleEvent cmdChan = \case
+  AppEvent EvConnected -> do
+    -- TODO
+    -- switch to MainScreenState with appropriate initial state
+    undefined
+  VtyEvent (V.EvKey (V.KChar 'q') []) -> halt $ AppState cmdChan ConnectingScreenState
+  _ -> continue $ AppState cmdChan ConnectingScreenState
+
+handleEvent ::
+  AppState ->
+  BrickEvent VibeMenuName CustomEvent ->
+  EventM VibeMenuName (Next AppState)
+handleEvent (AppState cmdChan screenState) ev = case screenState of
+  ConnectScreenState form -> connectScreenHandleEvent form cmdChan ev
+  -- For now, I don't think ConnectingScreenState should need to send any commands
+  ConnectingScreenState -> connectingStateHandleEvent cmdChan ev
+  MainScreenState mss -> vibeMenuHandleEvent mss cmdChan ev
+
+-- TODO continueWithoutRedraw where appropriate
+vibeMenuHandleEvent ::
+  VibeMenuState ->
+  BChan Command ->
+  BrickEvent VibeMenuName CustomEvent ->
+  EventM VibeMenuName (Next AppState)
+vibeMenuHandleEvent s cmdChan = \case
   VtyEvent e -> case e of
-    V.EvResize {} -> continue s
-    V.EvKey V.KEsc [] -> halt s
+    V.EvResize {} -> continue $ AppState cmdChan $ MainScreenState s
+    V.EvKey V.KEsc [] -> halt $ AppState cmdChan $ MainScreenState s
     V.EvKey (V.KChar c) [] -> case c of
-      's' -> do 
-        sendCommand (s ^. cmdChan) CmdStopAll
-        continue s
-      'q' -> halt s
-      _ | isDigit c -> do
-          withSelectedDevice \(_, Device _ devIndex _) -> do
-             let strength = if c == '0' then 1
-                                        else fromIntegral (ord c - 48) / 10
-             sendCommand (s ^. cmdChan) (CmdVibrate devIndex strength)
-          continue s
-        | otherwise -> continue s
-    -- V.EvKey (V.KChar c) [] 
+      's' -> do
+        sendCommand cmdChan $ CmdButtplug CmdStopAll
+        continue $ AppState cmdChan $ MainScreenState s
+      'q' -> halt $ AppState cmdChan $ MainScreenState s
+      _
+        | isDigit c -> do
+            withSelectedDevice \(_, Device _ devIndex _) -> do
+              let strength =
+                    if c == '0'
+                      then 1
+                      else fromIntegral (ord c - 48) / 10
+              sendCommand cmdChan (CmdButtplug $ CmdVibrate devIndex strength)
+            continue $ AppState cmdChan $ MainScreenState s
+        | otherwise -> continue $ AppState cmdChan $ MainScreenState s
+    -- V.EvKey (V.KChar c) []
     --   | '0' <= c && c <= '9' -> do
     --     withSelectedDevice \(_, Device _ devIndex _) -> do
     --        let strength = if c == '0' then 1
     --                                   else fromIntegral (ord c - 48) / 10
     --        sendCommand (s ^. cmdChan) (CmdVibrate devIndex strength)
     --     continue s
-    --   | c == 's' -> do 
+    --   | c == 's' -> do
     --     sendCommand (s ^. cmdChan) CmdStopAll
     --     continue s
     --   | otherwise -> continue s
-    e -> handleEventLensed s devices L.handleListEvent e >>= continue
+    e -> do
+      s' <- handleEventLensed s devices L.handleListEvent e
+      continue $ AppState cmdChan $ MainScreenState s'
   AppEvent e -> case e of
-    ReceivedMessage msg -> continue $ s & messageLog %~
-      (listAppend msg .> L.listMoveToEnd)
+    ReceivedMessage msg ->
+      continue $
+        AppState cmdChan $
+          MainScreenState $
+            s
+              & messageLog
+                %~ (listAppend msg .> L.listMoveToEnd)
     ReceivedDeviceList devs ->
-      continue $ s & devices .~ L.list DeviceMenu (Vec.fromList devs) 1
+      continue $ AppState cmdChan $ MainScreenState $ s & devices .~ L.list DeviceMenu (Vec.fromList devs) 1
     EvDeviceAdded dev@(Device devName (fromIntegral -> ix) _) ->
-      continue $ s & devices %~ listAppend dev
+      continue $ AppState cmdChan $ MainScreenState $ s & devices %~ listAppend dev
     EvDeviceRemoved (fromIntegral -> ix) ->
-      continue $ s & devices %~ deleteDeviceByIndex ix
-  _ -> continue s
-  where selectedDevice = s ^. devices & L.listSelectedElement
+      continue $ AppState cmdChan $ MainScreenState $ s & devices %~ deleteDeviceByIndex ix
+  _ -> continue $ AppState cmdChan $ MainScreenState s
+  where
+    selectedDevice = s ^. devices & L.listSelectedElement
 
-        withSelectedDevice :: ((Int, Device) -> EventM VibeMenuName ())
-                           -> EventM VibeMenuName ()
-        withSelectedDevice k = case selectedDevice of
-          Just d  -> k d
-          Nothing -> pure ()
+    withSelectedDevice ::
+      ((Int, Device) -> EventM VibeMenuName ()) ->
+      EventM VibeMenuName ()
+    withSelectedDevice k = case selectedDevice of
+      Just d -> k d
+      Nothing -> pure ()
 
 listAppend :: e -> L.List n e -> L.List n e
-listAppend elt l = let n = Vec.length $ L.listElements l
-                    in L.listInsert n elt l
+listAppend elt l =
+  let n = Vec.length $ L.listElements l
+   in L.listInsert n elt l
 
 deleteDeviceByIndex :: Word -> L.List n Device -> L.List n Device
 deleteDeviceByIndex devIx l =
-  case Vec.findIndex ((devIx==) . deviceIndex) (L.listElements l) of
+  case Vec.findIndex ((devIx ==) . deviceIndex) (L.listElements l) of
     Just listIndex -> L.listRemove listIndex l
     Nothing -> l
 
+-- getHostPort :: IO (String, Int, V.Vty)
+-- getHostPort = do
+--   args <- getArgs
+--   initialVty <- buildVty
+--   case args of
+--     [host, port] -> pure (host, read port, initialVty)
+--     _ -> do
+--       let initialHost = "127.0.0.1"
+--           connectForm = setFieldValid True PortField $ mkForm initialHostPort
+--           initialHostPort = HostPort initialHost 12345
 
-getHostPort :: IO (String, Int, V.Vty)
-getHostPort = do
-    args <- getArgs
-    initialVty <- buildVty
-    case args of
-      [host, port] -> pure (host, read port, initialVty)
-      _      -> do
-
-        let initialHost = "127.0.0.1"
-            connectForm = setFieldValid True PortField $
-              mkForm initialHostPort
-            initialHostPort = HostPort initialHost 12345
-
-        (connectForm', vty') <- customMainWithVty
-          initialVty buildVty Nothing connectScreen connectForm
-        if allFieldsValid connectForm'
-           then do
-             putStrLn "The final form inputs were valid."
-             let HostPort host port = formState connectForm' 
-             pure (T.unpack host, port, vty')
-           else do 
-             putStrLn $ "The final form had invalid inputs: " <>
-               show (invalidFields connectForm')
-             exitFailure
+--       (connectForm', vty') <-
+--         customMainWithVty
+--           initialVty
+--           buildVty
+--           Nothing
+--           connectScreen
+--           connectForm
+--       if allFieldsValid connectForm'
+--         then do
+--           putStrLn "The final form inputs were valid."
+--           let HostPort host port = formState connectForm'
+--           pure (T.unpack host, port, vty')
+--         else do
+--           putStrLn $
+--             "The final form had invalid inputs: "
+--               <> show (invalidFields connectForm')
+--           exitFailure
 
 buildVty = do
-      v <- V.mkVty =<< V.standardIOConfig
-      V.setMode (V.outputIface v) V.Mouse True
-      return v
+  v <- V.mkVty =<< V.standardIOConfig
+  V.setMode (V.outputIface v) V.Mouse True
+  return v
+
+initialMainScreenState :: VibeMenuState
+initialMainScreenState =
+  VibeMenuState
+    (L.list MessageLog mempty 1)
+    (L.list DeviceMenu mempty 1)
 
 main :: IO ()
 main = do
+  vty <- buildVty
+  args <- getArgs
+  let mConnector = case args of
+        [host, port] -> Just $ BPWS.Connector host (read port)
+        _ -> Nothing
 
-    (host, port, vty) <- getHostPort
-    cmdChan <- newBChan 30
+  cmdChan <- newBChan 30
 
-    let connector = BPWS.Connector host port
-        initialState = VibeMenuState (L.list MessageLog mempty 1)
-                                     (L.list DeviceMenu mempty 1)
-                                     cmdChan
+  let defaultHostPort = HostPort "127.0.0.1" 12345
+      connectForm = setFieldValid True PortField $ mkForm defaultHostPort
+      initialState = AppState cmdChan $ case mConnector of
+        Just connector -> ConnectingScreenState
+        Nothing -> ConnectScreenState connectForm
 
+      startEvent = case mConnector of
+        Just connector -> \s -> do
+          sendCommand cmdChan (CmdConnect connector)
+          pure s
+        Nothing -> pure
 
-    putStrLn $ "Connecting to: " <> host <> ":" <> show port
-    BPWS.runClient connector \con -> do
-      putStrLn "connected!"
-      evChan <- newBChan 10 -- tweak chan capacity
-      race_
-        (handleMsgs con evChan cmdChan)
-        (customMain vty buildVty (Just evChan) vibeMenu initialState)
-      pure ()
+  evChan <- newBChan 10 -- tweak chan capacity
+  race_
+    (handleCommands evChan cmdChan)
+    (customMain vty buildVty (Just evChan) vibeMenu initialState)
+  pure ()
 
+handleCommands :: BChan CustomEvent -> BChan Command -> IO ()
+handleCommands evChan cmdChan = do
+  -- used for forwarding buttplug specific commands to the thread connected to
+  -- the buttplug server
+  buttplugCmdsChan :: BChan ButtplugCommand <- newBChan 5
+  connected <- newEmptyMVar
 
--- Background threads which handle communication with the server
-handleMsgs :: Buttplug.Handle
-           -> BChan CustomEvent
-           -> BChan Command
-           -> IO ()
-handleMsgs con evChan cmdChan = do
+  let handleCommand :: Command -> IO ()
+      handleCommand command = do
+        hPutStrLn stderr $ "DEBUG: got command: " <> show command
+        case command of
+          CmdConnect connector -> connect connector
+          CmdButtplug cmd -> do
+            tryTakeMVar connected >>= \case
+              -- we need a way to forward some UI commands to the thread thats
+              -- connected to buttplug, if it exists
+              Just () -> writeBChan buttplugCmdsChan cmd
+              -- we shouldn't be getting ButtplugCommands when we're not connected
+              Nothing -> error "received ButtplugCommand from ui when not connected to the buttplug server!"
+
+      connect :: BPWS.Connector -> IO ()
+      connect connector = do
+        putStrLn $
+          "Connecting to: "
+            ++ connector.wsConnectorHost
+            ++ ":"
+            ++ show connector.wsConnectorPort
+        BPWS.runClient connector \handle -> do
+          putStrLn "connected!"
+          putMVar connected ()
+          handleMsgs handle evChan buttplugCmdsChan
+          pure ()
+        takeMVar connected
+
+  -- TODO handle in parallel
+  S.mapM_ handleCommand $
+    S.fromParallel $
+      S.repeatM (readBChan cmdChan)
+
+handleMsgs ::
+  Buttplug.Handle ->
+  BChan CustomEvent ->
+  BChan ButtplugCommand ->
+  IO ()
+handleMsgs handle evChan buttplugCmdsChan = do
   -- block while we perform handshake
-  Buttplug.sendMessage con $ MsgRequestServerInfo 1 "VibeMenu" clientMessageVersion
-  [servInfo@(MsgServerInfo 1 _ _ _)] <- Buttplug.receiveMessages con
+  Buttplug.sendMessage handle $ MsgRequestServerInfo 1 "VibeMenu" clientMessageVersion
+  [servInfo@(MsgServerInfo 1 _ _ _)] <- Buttplug.receiveMessages handle
   writeBChan evChan $ ReceivedMessage servInfo
 
-  mapConcurrently_ id
-    [ Buttplug.sendMessage con $ MsgRequestDeviceList 2
-    , Buttplug.sendMessage con $ MsgStartScanning 3
-    -- main loop
-    , buttplugMessages con
-      |> S.concatMap (toEvents .> S.fromFoldable)
-      |> S.mapM_ (writeBChan evChan)
-    , uiCmds cmdChan
-      |> S.mapM_ (handleCmd con)
+  mapConcurrently_
+    id
+    [ Buttplug.sendMessage handle $ MsgRequestDeviceList 2,
+      Buttplug.sendMessage handle $ MsgStartScanning 3,
+      -- main loop
+      buttplugMessages handle
+        |> S.concatMap (toEvents .> S.fromFoldable)
+        |> S.mapM_ (writeBChan evChan),
+      S.mapM_ handleButtplugCmd $
+        S.repeatM $
+          readBChan buttplugCmdsChan
     ]
-
-handleCmd :: Buttplug.Handle -> Command -> IO ()
-handleCmd con = \case
-  CmdStopAll             -> Buttplug.sendMessage con $ MsgStopAllDevices 1
-  CmdVibrate devIx speed -> Buttplug.sendMessage con $
-    MsgVibrateCmd 1 devIx [Vibrate 0 speed]
-
+  where
+    handleButtplugCmd :: ButtplugCommand -> IO ()
+    handleButtplugCmd = \case
+      CmdStopAll -> Buttplug.sendMessage handle $ MsgStopAllDevices 1
+      CmdVibrate devIx speed ->
+        Buttplug.sendMessage handle $
+          MsgVibrateCmd 1 devIx [Vibrate 0 speed]
 
 uiCmds :: (IsStream t) => BChan Command -> t IO Command
 uiCmds chan = S.repeatM (readBChan chan)
 
 -- Produces all messages that come in through a buttplug connection
-buttplugMessages :: IsStream t
-                 => Buttplug.Handle -> t IO Message
---buttplugMessages con = forever $ lift (receiveMsgs con) >>= each
-buttplugMessages con = S.repeatM (Buttplug.receiveMessages con)
-                     & S.concatMap S.fromFoldable
-
+buttplugMessages ::
+  IsStream t =>
+  Buttplug.Handle ->
+  t IO Message
+-- buttplugMessages con = forever $ lift (receiveMsgs con) >>= each
+buttplugMessages con =
+  S.repeatM (Buttplug.receiveMessages con)
+    & S.concatMap S.fromFoldable
 
 -- We notify the UI of every message so it can display them, but also
 -- translate messages into simplified events
 toEvents :: Message -> [CustomEvent]
-toEvents msg = catMaybes
-  [ Just $ ReceivedMessage msg
-  , msgToCustomEvent msg
-  ]
+toEvents msg =
+  catMaybes
+    [ Just $ ReceivedMessage msg,
+      msgToCustomEvent msg
+    ]
   where
-  -- Translate messages that the UI needs to know about to events, discarding 
-  -- the unnecessary ones
-  msgToCustomEvent :: Message -> Maybe CustomEvent
-  msgToCustomEvent = \case
-    MsgDeviceAdded _ name ix devmsgs -> Just $ EvDeviceAdded $ Device name ix devmsgs
-    MsgDeviceRemoved _ ix            -> Just $ EvDeviceRemoved ix
-    MsgDeviceList _ devices          -> Just $ ReceivedDeviceList devices
-    _ -> Nothing
+    -- Translate messages that the UI needs to know about to events, discarding
+    -- the unnecessary ones
+    -- TODO this function is mostly just for ignoring message indices. This should reside in
+    -- a high level buttplug library. Users of buttplug shouldn't have to worry about message
+    -- indices
+    msgToCustomEvent :: Message -> Maybe CustomEvent
+    msgToCustomEvent = \case
+      MsgDeviceAdded _ name ix devmsgs -> Just $ EvDeviceAdded $ Device name ix devmsgs
+      MsgDeviceRemoved _ ix -> Just $ EvDeviceRemoved ix
+      MsgDeviceList _ devices -> Just $ ReceivedDeviceList devices
+      _ -> Nothing

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,7 +41,7 @@ packages:
 #
 extra-deps:
 - git: git@github.com:sullyj3/buttplug-hs-core.git
-  commit: f2002cb540aa6bf1b3e821716cb0b05b83ed5f9a
+  commit: e68c97a9931575c542c0cccceca9a09b238d7145
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: nightly-2021-03-20
+resolver: nightly-2022-07-21
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -41,7 +41,7 @@ packages:
 #
 extra-deps:
 - git: git@github.com:sullyj3/buttplug-hs-core.git
-  commit: 0a7856a5b14c41438c74f14af8c0ddcd107f4b4b
+  commit: f2002cb540aa6bf1b3e821716cb0b05b83ed5f9a
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -40,7 +40,8 @@ packages:
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
 #
 extra-deps:
-
+- git: git@github.com:sullyj3/buttplug-hs-core.git
+  commit: 0a7856a5b14c41438c74f14af8c0ddcd107f4b4b
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,18 +6,18 @@
 packages:
 - completed:
     name: buttplug-hs-core
-    version: 0.2.0.1
+    version: 0.2.0.0
     git: git@github.com:sullyj3/buttplug-hs-core.git
     pantry-tree:
-      size: 1025
-      sha256: bed5d33a62a0a48db09e29388e7855f44173ed35ee3bcb6c0bd3c19ddf8dd9aa
-    commit: 0a7856a5b14c41438c74f14af8c0ddcd107f4b4b
+      size: 1026
+      sha256: 57d1d4ae83df1c337c1bacdfc69bfe5218e813ce54f2950667156437ad9ad064
+    commit: f2002cb540aa6bf1b3e821716cb0b05b83ed5f9a
   original:
     git: git@github.com:sullyj3/buttplug-hs-core.git
-    commit: 0a7856a5b14c41438c74f14af8c0ddcd107f4b4b
+    commit: f2002cb540aa6bf1b3e821716cb0b05b83ed5f9a
 snapshots:
 - completed:
-    size: 574369
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2021/3/20.yaml
-    sha256: d4297470fde92e7794ced8e4b490a4f1733c1d7c840c4de74f6006b2a83b2b0c
-  original: nightly-2021-03-20
+    size: 617441
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2022/7/21.yaml
+    sha256: 79dd565ad2ddaca3300032a592912aaf95d6da96cb385d027cd91acb62fa7107
+  original: nightly-2022-07-21

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -10,11 +10,11 @@ packages:
     git: git@github.com:sullyj3/buttplug-hs-core.git
     pantry-tree:
       size: 1026
-      sha256: 57d1d4ae83df1c337c1bacdfc69bfe5218e813ce54f2950667156437ad9ad064
-    commit: f2002cb540aa6bf1b3e821716cb0b05b83ed5f9a
+      sha256: 0105b623f6d59af669a7d8a4c19f3fcb7d2da44d5a31c0c60d76e761224273dc
+    commit: e68c97a9931575c542c0cccceca9a09b238d7145
   original:
     git: git@github.com:sullyj3/buttplug-hs-core.git
-    commit: f2002cb540aa6bf1b3e821716cb0b05b83ed5f9a
+    commit: e68c97a9931575c542c0cccceca9a09b238d7145
 snapshots:
 - completed:
     size: 617441

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,7 +3,18 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    name: buttplug-hs-core
+    version: 0.2.0.1
+    git: git@github.com:sullyj3/buttplug-hs-core.git
+    pantry-tree:
+      size: 1025
+      sha256: bed5d33a62a0a48db09e29388e7855f44173ed35ee3bcb6c0bd3c19ddf8dd9aa
+    commit: 0a7856a5b14c41438c74f14af8c0ddcd107f4b4b
+  original:
+    git: git@github.com:sullyj3/buttplug-hs-core.git
+    commit: 0a7856a5b14c41438c74f14af8c0ddcd107f4b4b
 snapshots:
 - completed:
     size: 574369


### PR DESCRIPTION
## What
Previously the program consisted of two `brick` `App`s - the first a dialogue to get the host and port to connect to, the second for the main application. This was a very hacky solution, arising from the fact that I wasn't sure how to reconcile the type of
    
```haskell
Buttplug.runClient :: Connector -> (Handle -> IO a) -> IO a
```    
    
with the fact that the phase of the program where we input the host and port needs to run without being connected.
This PR refactors the program into a single brick `App` with multiple screens.

In no particular order: (TODO order by dependency to enable retrying this refactor with smaller commits)

- Format with ormolu (should've done this separately)
- Merge constructors of `ConnectScreenName` with `VibeMenuName`
- Add new `Command`: `CmdConnect connector`, extract other buttplug message related commands into new `ButtplugCommand` type
- Add `EvConnected` to `CustomEvent`, allowing background thread to notify UI when we're connected
- Add `ScreenState` type which holds state specific to the screens
    ```haskell
    data ScreenState
      = ConnectScreenState ConnectScreenState
      | ConnectingScreenState
      | MainScreenState VibeMenuState
    ```
- Add `AppState` which contains a `BChan Command` and a `ScreenState`
  - Probably the `cmdChan` shouldn't go in the state, since it doesn't change. It would be better to manually pass it as an argument, or put it in a `ReaderT` instead.
- TODO More

## Introduced bug

I introduced a bug in [ba9615c](https://github.com/sullyj3/Vibe-menu/pull/2/commits/ba9615cf9bd63c7e43c56e80b54b20325f84c0b9) or [03207c7](https://github.com/sullyj3/Vibe-menu/pull/2/commits/03207c76b49342d7fd3f0da449c4a54860279931) where the client fails to send pongs at the websocket layer (not the buttplug protocol layer, I've been testing using intiface servers with timeout disabled).

```bash
⮞ ./IntifaceCLI --wsinsecureport 12345 --pingtime 0 --stayopen --wsallinterfaces
Intiface Server, starting up with stdout output.
[...]
2022-07-22T05:22:25.097408Z  INFO buttplug::connector::transport::websocket::websocket_server: Websocket: Got connection
2022-07-22T05:22:25.097731Z  INFO buttplug::connector::transport::websocket::websocket_server: Starting websocket server connection event loop.
2022-07-22T05:22:25.097738Z  INFO buttplug::server::remote_server: Starting remote server loop
2022-07-22T05:22:25.099011Z  INFO buttplug::core::messages::serializer::json_serializer: Setting JSON Wrapper message version to Version2
2022-07-22T05:22:25.099045Z  INFO buttplug::server: Performing server handshake check with client VibeMenu at message version Version2.
2022-07-22T05:22:25.099091Z  INFO intiface_cli: Client connected: VibeMenu    
2022-07-22T05:22:25.099100Z  INFO intiface_cli: Rejecting all incoming clients while connected    
[...]
2022-07-22T05:22:42.102752Z  WARN buttplug::connector::transport::websocket::websocket_server: No pongs received, considering connection closed.
2022-07-22T05:22:42.104242Z  INFO buttplug::server::remote_server: Connector disconnected, exiting loop.
2022-07-22T05:22:42.104442Z  INFO buttplug::server: Server disconnected, stopping device scanning if it was started...
2022-07-22T05:22:42.104587Z  INFO buttplug::server: Server disconnected, stopping all devices...
2022-07-22T05:22:42.104599Z  INFO buttplug::server::remote_server: Exiting remote server loop
2022-07-22T05:22:42.104630Z  INFO intiface_cli: Connection dropped, restarting stay open loop.    
2022-07-22T05:22:42.104650Z  INFO buttplug::server::device_manager: Dropping device manager!
2022-07-22T05:22:42.104719Z  INFO intiface_cli: Exiting    
```

Not sure what I did. I may end up having to scrap this PR and try the refactor again, this time making more of an effort to break it up into smaller, buildable commits.

## Reattempt:
### On `main`:
1. Format
2. Rename `CustomEvent` to something sensible

### On refactor branch:
1. Completely rip out the host/port input screen, replace with mandatory command line args
2. **Most likely the bug will be introduced here**: Factor such that the call to `Buttplug.runClient` doesn't surround the call to `Brick.customMain`, but instead happens in a background thread while starting. If we get the bug again try ripping out `streamly` and just using `async` for now.
3. Create `CmdConnect connector`, separate buttplug specific commands into separate type. Don't do anything with it yet
4. Add `EvConnected` to `CustomEvent`
5. Rather than hard coding the `connect` to run on app start, have the ui immediately send a `CmdConnect` to the background thread, which will connect, and send the ui an `EvConnected`.
6. Add "Connecting" Screen. Use tip from jdaugherty about always taking and return full state, with partial lenses for access
  a. `data AppState = MainScreen MainScreenState | ConnectingScreen` but don't pass it to `App` yet
  b. create partial lens for accessing `MainScreenState`
  c. create functions for handling events and viewing for `ConnectingScreen`, don't hook them up yet

`TODO`