### PR TITLE
Re-add connect screen

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -110,26 +110,30 @@ data Command
   = BPCommand ButtplugCommand
   | CmdConnect BPWS.Connector
 
-data AppState = MainScreenState MainScreenState | ConnectingScreen
+data AppState = MainScreen MainScreenState | ConnectingScreen
 
 mainScreenState :: Lens' AppState MainScreenState
 mainScreenState = lens get set
   where
     get = \case
-      MainScreenState mss -> mss
+      MainScreen mss -> mss
       _ -> error "BUG: mainScreenState: tried to get MainScreenState from incorrect constructor"
 
     set appState mss = case appState of
-      MainScreenState _ -> MainScreenState mss
+      MainScreen _ -> MainScreen mss
       _ ->
         error
           "BUG: mainScreenState: tried to write MainScreenState to incorrect constructor field"
 
-data MainScreenState = VibeMenuState
+data MainScreenState = MainScreenState
   { _messageLog :: L.List VibeMenuName Message,
     _devices :: L.List VibeMenuName Device,
     _cmdChan :: BChan Command
   }
+  -- { _messageLog :: L.List VibeMenuName Message,
+  --   _devices :: L.List VibeMenuName Device,
+  --   _cmdChan :: BChan Command
+  -- }
 
 makeLenses ''MainScreenState
 
@@ -281,7 +285,7 @@ main = do
 
   let connector = BPWS.Connector host port
       initialState =
-        VibeMenuState
+        MainScreenState
           (L.list MessageLog mempty 1)
           (L.list DeviceMenu mempty 1)
           cmdChan

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -110,13 +110,13 @@ data Command
   = BPCommand ButtplugCommand
   | CmdConnect BPWS.Connector
 
-data VibeMenuState = VibeMenuState
+data MainScreenState = VibeMenuState
   { _messageLog :: L.List VibeMenuName Message,
     _devices :: L.List VibeMenuName Device,
     _cmdChan :: BChan Command
   }
 
-makeLenses ''VibeMenuState
+makeLenses ''MainScreenState
 
 -- events from bg thread to UI thread
 data VibeMenuEvent = EvConnected | BPEvent BPSessionEvent
@@ -161,8 +161,8 @@ listDrawElement sel a =
    in (selStr $ show a)
 
 vibeMenu ::
-  (VibeMenuState -> EventM VibeMenuName VibeMenuState) ->
-  App VibeMenuState VibeMenuEvent VibeMenuName
+  (MainScreenState -> EventM VibeMenuName MainScreenState) ->
+  App MainScreenState VibeMenuEvent VibeMenuName
 vibeMenu startEvent =
   App
     { appDraw = drawVibeMenu,
@@ -173,9 +173,9 @@ vibeMenu startEvent =
     }
 
 vibeMenuHandleEvent ::
-  VibeMenuState ->
+  MainScreenState ->
   BrickEvent VibeMenuName VibeMenuEvent ->
-  EventM VibeMenuName (Next VibeMenuState)
+  EventM VibeMenuName (Next MainScreenState)
 vibeMenuHandleEvent s = \case
   VtyEvent e -> case e of
     V.EvResize {} -> continue s

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -63,7 +63,7 @@ import Data.Vector (Vector)
 import Data.Vector qualified as Vec
 import Graphics.Vty qualified as V
 import Ki
-import Lens.Micro ((%~), (&), (.~), (^.))
+import Lens.Micro (Lens', lens, set, (%~), (&), (.~), (^.))
 import Lens.Micro.TH
 import Streamly.Prelude (IsStream, nil, (|:))
 import Streamly.Prelude qualified as S
@@ -109,6 +109,21 @@ data ButtplugCommand
 data Command
   = BPCommand ButtplugCommand
   | CmdConnect BPWS.Connector
+
+data AppState = MainScreenState MainScreenState | ConnectingScreen
+
+mainScreenState :: Lens' AppState MainScreenState
+mainScreenState = lens get set
+  where
+    get = \case
+      MainScreenState mss -> mss
+      _ -> error "BUG: mainScreenState: tried to get MainScreenState from incorrect constructor"
+
+    set appState mss = case appState of
+      MainScreenState _ -> MainScreenState mss
+      _ ->
+        error
+          "BUG: mainScreenState: tried to write MainScreenState to incorrect constructor field"
 
 data MainScreenState = VibeMenuState
   { _messageLog :: L.List VibeMenuName Message,

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -59,6 +59,7 @@ import Data.Foldable (traverse_)
 import Data.Maybe (catMaybes)
 import Data.Semigroup (First (..))
 import Data.Text qualified as T
+import Data.Text (Text)
 import Data.Vector (Vector)
 import Data.Vector qualified as Vec
 import Graphics.Vty qualified as V
@@ -76,7 +77,7 @@ data ConnectScreenName
   | PortField
   deriving (Eq, Ord, Show)
 
-data HostPort = HostPort {_host :: String, _port :: Int}
+data HostPort = HostPort {_host :: Text, _port :: Int}
   deriving (Show, Eq)
 
 makeLenses ''HostPort
@@ -114,6 +115,20 @@ data MainScreenState = MainScreenState
   { _messageLog :: L.List VibeMenuName Message,
     _devices :: L.List VibeMenuName Device
   }
+
+-- type ConnectForm = Form HostPort AppEvent VibeMenuName
+
+-- mkForm :: HostPort -> Form HostPort e VibeMenuName
+-- mkForm =
+--   let label s w =
+--         padBottom (Pad 1) $
+--           vLimit 1 (hLimit 15 $ str s <+> fill ' ') <+> w
+--    in newForm
+--         [ label "Host"
+--             @@= editTextField host HostField (Just 1),
+--           label "Port"
+--             @@= editShowableField port PortField
+--         ]
 
 makeLenses ''MainScreenState
 
@@ -290,7 +305,7 @@ getHostPort :: IO HostPort
 getHostPort = do
   args <- getArgs
   pure $ case args of
-    [host, port] -> HostPort host (read port)
+    [host, port] -> HostPort (T.pack host) (read port)
     [port] -> HostPort defaultHost (read port)
     [] -> HostPort defaultHost defaultPort
   where
@@ -309,7 +324,7 @@ main = do
 
   vty <- buildVty
 
-  let connector = BPWS.Connector host port
+  let connector = BPWS.Connector (T.unpack host) port
       initialState = AppState cmdChan ConnectingScreen
 
       startEvent s = do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -328,7 +328,6 @@ connect connector buttplugCmdChan evChan = do
     "Connecting to: " <> connector.wsConnectorHost <> ":" <> show connector.wsConnectorPort
   -- TODO handle exceptions
   BPWS.runClient connector \handle -> do
-    putStrLn "connected!"
     writeBChan evChan EvConnected
     sendReceiveBPMessages handle evChan buttplugCmdChan
 

--- a/package.yaml
+++ b/package.yaml
@@ -21,13 +21,14 @@ description:         Please see the README on GitHub at <https://github.com/gith
 
 dependencies:
 - base >= 4.7 && < 5
-- async
 - brick
 - buttplug-hs-core
+- ki
 - microlens
 - microlens-th
 - process
 - streamly
+- stm
 - text
 - vector
 - vty

--- a/package.yaml
+++ b/package.yaml
@@ -22,7 +22,6 @@ description:         Please see the README on GitHub at <https://github.com/gith
 dependencies:
 - base >= 4.7 && < 5
 - async
-- flow
 - brick
 - buttplug-hs-core
 - microlens

--- a/vibe-menu.cabal
+++ b/vibe-menu.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 732149091fccd4e91316cfaee1b9516a3bed5893ef1c8bee956c93cc78c9821f
+-- hash: 8d3c9e5cd1073757fa8eaf0c5e31f1af42715431e502960e4eb431fe95b6e7a9
 
 name:           vibe-menu
 version:        0.1.0.0
@@ -33,13 +33,14 @@ library
   hs-source-dirs:
       src
   build-depends:
-      async
-    , base >=4.7 && <5
+      base >=4.7 && <5
     , brick
     , buttplug-hs-core
+    , ki
     , microlens
     , microlens-th
     , process
+    , stm
     , streamly
     , text
     , vector
@@ -54,13 +55,14 @@ executable vibe-menu
       app
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      async
-    , base >=4.7 && <5
+      base >=4.7 && <5
     , brick
     , buttplug-hs-core
+    , ki
     , microlens
     , microlens-th
     , process
+    , stm
     , streamly
     , text
     , vector
@@ -77,13 +79,14 @@ test-suite vibe-menu-test
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      async
-    , base >=4.7 && <5
+      base >=4.7 && <5
     , brick
     , buttplug-hs-core
+    , ki
     , microlens
     , microlens-th
     , process
+    , stm
     , streamly
     , text
     , vector

--- a/vibe-menu.cabal
+++ b/vibe-menu.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 564b4aeeba96e2c6ecbbdc1593252da6b22e2f1b8f64cdb154f025c373c89019
+-- hash: 732149091fccd4e91316cfaee1b9516a3bed5893ef1c8bee956c93cc78c9821f
 
 name:           vibe-menu
 version:        0.1.0.0
@@ -37,7 +37,6 @@ library
     , base >=4.7 && <5
     , brick
     , buttplug-hs-core
-    , flow
     , microlens
     , microlens-th
     , process
@@ -59,7 +58,6 @@ executable vibe-menu
     , base >=4.7 && <5
     , brick
     , buttplug-hs-core
-    , flow
     , microlens
     , microlens-th
     , process
@@ -83,7 +81,6 @@ test-suite vibe-menu-test
     , base >=4.7 && <5
     , brick
     , buttplug-hs-core
-    , flow
     , microlens
     , microlens-th
     , process


### PR DESCRIPTION
- [x] Create `CmdConnect connector`, separate buttplug specific commands into separate type. Don't do anything with it yet
- [x] Add `EvConnected` to `CustomEvent`
- [x] Rather than hard coding the `connect` to run on app start, have the ui immediately send a `CmdConnect` to the background thread, which will connect, and send the ui an `EvConnected`.
- [x] Add "Connecting" Screen. Use tip from jdaugherty about always taking and return full state, with partial lenses for access
  - [x] rename `VibeMenuState` to `MainScreenState`
  - [x] `data AppState = MainScreen MainScreenState | ConnectingScreen` but don't pass it to `App` yet
  - [x] create partial lens for accessing `MainScreenState`
  - [x] pass `AppState` to `App` instead of `MainScreenState`. Create view and event handler functions which crash if we're in `ConnectingScreen` state
  - [x] create functions for handling events and viewing for `ConnectingScreen`, and hook them up
- [x] Create connect screen for entering host and port